### PR TITLE
README: highlight example as C

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ LPeg
 
 # example
 
-````
+```c
 $ cat example.c
 #include <stdio.h>
 
@@ -53,6 +53,6 @@ int main(int argc, char *argv[]) {
   printf(STRSYM__S_N, x);
   return 42;
 }
-````
+```
 
 


### PR DESCRIPTION
I think the example in the README looks a little better with syntax highlighting:

https://github.com/chriskuehl/move-literals/blob/053e900228903531a18dd1e2ecacdb021eb34698/README.md
